### PR TITLE
Fix wrapping and unwrapping code

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -14,12 +14,12 @@ init_logging <- function(log_level) {
     invisible(.Call('bindrcpp_init_logging', PACKAGE = 'bindrcpp', log_level))
 }
 
-callback_string <- function(name, fun, payload) {
-    .Call('bindrcpp_callback_string', PACKAGE = 'bindrcpp', name, fun, payload)
+callback_string <- function(name, fun_and_payload) {
+    .Call('bindrcpp_callback_string', PACKAGE = 'bindrcpp', name, fun_and_payload)
 }
 
-callback_symbol <- function(name, fun, payload) {
-    .Call('bindrcpp_callback_symbol', PACKAGE = 'bindrcpp', name, fun, payload)
+callback_symbol <- function(name, fun_and_payload) {
+    .Call('bindrcpp_callback_symbol', PACKAGE = 'bindrcpp', name, fun_and_payload)
 }
 
 do_test_create_environment <- function(names, xform, parent) {

--- a/inst/include/bindrcpp_RcppExports.h
+++ b/inst/include/bindrcpp_RcppExports.h
@@ -35,7 +35,7 @@ namespace bindrcpp {
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_create_env_string(Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload), Rcpp::wrap(enclos));
+            rcpp_result_gen = p_create_env_string(Shield<SEXP>(Rcpp::wrap(names)), Shield<SEXP>(Rcpp::wrap(fun)), Shield<SEXP>(Rcpp::wrap(payload)), Shield<SEXP>(Rcpp::wrap(enclos)));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();
@@ -54,7 +54,7 @@ namespace bindrcpp {
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_populate_env_string(Rcpp::wrap(env), Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload));
+            rcpp_result_gen = p_populate_env_string(Shield<SEXP>(Rcpp::wrap(env)), Shield<SEXP>(Rcpp::wrap(names)), Shield<SEXP>(Rcpp::wrap(fun)), Shield<SEXP>(Rcpp::wrap(payload)));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();
@@ -73,7 +73,7 @@ namespace bindrcpp {
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_create_env_symbol(Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload), Rcpp::wrap(enclos));
+            rcpp_result_gen = p_create_env_symbol(Shield<SEXP>(Rcpp::wrap(names)), Shield<SEXP>(Rcpp::wrap(fun)), Shield<SEXP>(Rcpp::wrap(payload)), Shield<SEXP>(Rcpp::wrap(enclos)));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();
@@ -92,7 +92,7 @@ namespace bindrcpp {
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_populate_env_symbol(Rcpp::wrap(env), Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload));
+            rcpp_result_gen = p_populate_env_symbol(Shield<SEXP>(Rcpp::wrap(env)), Shield<SEXP>(Rcpp::wrap(names)), Shield<SEXP>(Rcpp::wrap(fun)), Shield<SEXP>(Rcpp::wrap(payload)));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();

--- a/inst/include/bindrcpp_RcppExports.h
+++ b/inst/include/bindrcpp_RcppExports.h
@@ -25,17 +25,17 @@ namespace bindrcpp {
         }
     }
 
-    inline Environment create_env_string(CharacterVector names, List fun_and_payload, Environment enclos) {
-        typedef SEXP(*Ptr_create_env_string)(SEXP,SEXP,SEXP);
+    inline Environment create_env_string(CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload, Environment enclos) {
+        typedef SEXP(*Ptr_create_env_string)(SEXP,SEXP,SEXP,SEXP);
         static Ptr_create_env_string p_create_env_string = NULL;
         if (p_create_env_string == NULL) {
-            validateSignature("Environment(*create_env_string)(CharacterVector,List,Environment)");
+            validateSignature("Environment(*create_env_string)(CharacterVector,bindrcpp::GETTER_FUNC_STRING,bindrcpp::PAYLOAD,Environment)");
             p_create_env_string = (Ptr_create_env_string)R_GetCCallable("bindrcpp", "bindrcpp_create_env_string");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_create_env_string(Rcpp::wrap(names), Rcpp::wrap(fun_and_payload), Rcpp::wrap(enclos));
+            rcpp_result_gen = p_create_env_string(Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload), Rcpp::wrap(enclos));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();
@@ -44,17 +44,17 @@ namespace bindrcpp {
         return Rcpp::as<Environment >(rcpp_result_gen);
     }
 
-    inline Environment populate_env_string(Environment env, CharacterVector names, List fun_and_payload) {
-        typedef SEXP(*Ptr_populate_env_string)(SEXP,SEXP,SEXP);
+    inline Environment populate_env_string(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload) {
+        typedef SEXP(*Ptr_populate_env_string)(SEXP,SEXP,SEXP,SEXP);
         static Ptr_populate_env_string p_populate_env_string = NULL;
         if (p_populate_env_string == NULL) {
-            validateSignature("Environment(*populate_env_string)(Environment,CharacterVector,List)");
+            validateSignature("Environment(*populate_env_string)(Environment,CharacterVector,bindrcpp::GETTER_FUNC_STRING,bindrcpp::PAYLOAD)");
             p_populate_env_string = (Ptr_populate_env_string)R_GetCCallable("bindrcpp", "bindrcpp_populate_env_string");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_populate_env_string(Rcpp::wrap(env), Rcpp::wrap(names), Rcpp::wrap(fun_and_payload));
+            rcpp_result_gen = p_populate_env_string(Rcpp::wrap(env), Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();
@@ -63,17 +63,17 @@ namespace bindrcpp {
         return Rcpp::as<Environment >(rcpp_result_gen);
     }
 
-    inline Environment create_env_symbol(CharacterVector names, List fun_and_payload, Environment enclos) {
-        typedef SEXP(*Ptr_create_env_symbol)(SEXP,SEXP,SEXP);
+    inline Environment create_env_symbol(CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload, Environment enclos) {
+        typedef SEXP(*Ptr_create_env_symbol)(SEXP,SEXP,SEXP,SEXP);
         static Ptr_create_env_symbol p_create_env_symbol = NULL;
         if (p_create_env_symbol == NULL) {
-            validateSignature("Environment(*create_env_symbol)(CharacterVector,List,Environment)");
+            validateSignature("Environment(*create_env_symbol)(CharacterVector,bindrcpp::GETTER_FUNC_SYMBOL,bindrcpp::PAYLOAD,Environment)");
             p_create_env_symbol = (Ptr_create_env_symbol)R_GetCCallable("bindrcpp", "bindrcpp_create_env_symbol");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_create_env_symbol(Rcpp::wrap(names), Rcpp::wrap(fun_and_payload), Rcpp::wrap(enclos));
+            rcpp_result_gen = p_create_env_symbol(Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload), Rcpp::wrap(enclos));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();
@@ -82,17 +82,17 @@ namespace bindrcpp {
         return Rcpp::as<Environment >(rcpp_result_gen);
     }
 
-    inline Environment populate_env_symbol(Environment env, CharacterVector names, List fun_and_payload) {
-        typedef SEXP(*Ptr_populate_env_symbol)(SEXP,SEXP,SEXP);
+    inline Environment populate_env_symbol(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload) {
+        typedef SEXP(*Ptr_populate_env_symbol)(SEXP,SEXP,SEXP,SEXP);
         static Ptr_populate_env_symbol p_populate_env_symbol = NULL;
         if (p_populate_env_symbol == NULL) {
-            validateSignature("Environment(*populate_env_symbol)(Environment,CharacterVector,List)");
+            validateSignature("Environment(*populate_env_symbol)(Environment,CharacterVector,bindrcpp::GETTER_FUNC_SYMBOL,bindrcpp::PAYLOAD)");
             p_populate_env_symbol = (Ptr_populate_env_symbol)R_GetCCallable("bindrcpp", "bindrcpp_populate_env_symbol");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_populate_env_symbol(Rcpp::wrap(env), Rcpp::wrap(names), Rcpp::wrap(fun_and_payload));
+            rcpp_result_gen = p_populate_env_symbol(Rcpp::wrap(env), Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();

--- a/inst/include/bindrcpp_RcppExports.h
+++ b/inst/include/bindrcpp_RcppExports.h
@@ -25,17 +25,17 @@ namespace bindrcpp {
         }
     }
 
-    inline Environment create_env_string(CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload, Environment enclos) {
-        typedef SEXP(*Ptr_create_env_string)(SEXP,SEXP,SEXP,SEXP);
+    inline Environment create_env_string(CharacterVector names, List fun_and_payload, Environment enclos) {
+        typedef SEXP(*Ptr_create_env_string)(SEXP,SEXP,SEXP);
         static Ptr_create_env_string p_create_env_string = NULL;
         if (p_create_env_string == NULL) {
-            validateSignature("Environment(*create_env_string)(CharacterVector,bindrcpp::GETTER_FUNC_STRING,bindrcpp::PAYLOAD,Environment)");
+            validateSignature("Environment(*create_env_string)(CharacterVector,List,Environment)");
             p_create_env_string = (Ptr_create_env_string)R_GetCCallable("bindrcpp", "bindrcpp_create_env_string");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_create_env_string(Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload), Rcpp::wrap(enclos));
+            rcpp_result_gen = p_create_env_string(Rcpp::wrap(names), Rcpp::wrap(fun_and_payload), Rcpp::wrap(enclos));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();
@@ -44,17 +44,17 @@ namespace bindrcpp {
         return Rcpp::as<Environment >(rcpp_result_gen);
     }
 
-    inline Environment populate_env_string(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload) {
-        typedef SEXP(*Ptr_populate_env_string)(SEXP,SEXP,SEXP,SEXP);
+    inline Environment populate_env_string(Environment env, CharacterVector names, List fun_and_payload) {
+        typedef SEXP(*Ptr_populate_env_string)(SEXP,SEXP,SEXP);
         static Ptr_populate_env_string p_populate_env_string = NULL;
         if (p_populate_env_string == NULL) {
-            validateSignature("Environment(*populate_env_string)(Environment,CharacterVector,bindrcpp::GETTER_FUNC_STRING,bindrcpp::PAYLOAD)");
+            validateSignature("Environment(*populate_env_string)(Environment,CharacterVector,List)");
             p_populate_env_string = (Ptr_populate_env_string)R_GetCCallable("bindrcpp", "bindrcpp_populate_env_string");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_populate_env_string(Rcpp::wrap(env), Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload));
+            rcpp_result_gen = p_populate_env_string(Rcpp::wrap(env), Rcpp::wrap(names), Rcpp::wrap(fun_and_payload));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();
@@ -63,17 +63,17 @@ namespace bindrcpp {
         return Rcpp::as<Environment >(rcpp_result_gen);
     }
 
-    inline Environment create_env_symbol(CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload, Environment enclos) {
-        typedef SEXP(*Ptr_create_env_symbol)(SEXP,SEXP,SEXP,SEXP);
+    inline Environment create_env_symbol(CharacterVector names, List fun_and_payload, Environment enclos) {
+        typedef SEXP(*Ptr_create_env_symbol)(SEXP,SEXP,SEXP);
         static Ptr_create_env_symbol p_create_env_symbol = NULL;
         if (p_create_env_symbol == NULL) {
-            validateSignature("Environment(*create_env_symbol)(CharacterVector,bindrcpp::GETTER_FUNC_SYMBOL,bindrcpp::PAYLOAD,Environment)");
+            validateSignature("Environment(*create_env_symbol)(CharacterVector,List,Environment)");
             p_create_env_symbol = (Ptr_create_env_symbol)R_GetCCallable("bindrcpp", "bindrcpp_create_env_symbol");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_create_env_symbol(Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload), Rcpp::wrap(enclos));
+            rcpp_result_gen = p_create_env_symbol(Rcpp::wrap(names), Rcpp::wrap(fun_and_payload), Rcpp::wrap(enclos));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();
@@ -82,17 +82,17 @@ namespace bindrcpp {
         return Rcpp::as<Environment >(rcpp_result_gen);
     }
 
-    inline Environment populate_env_symbol(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload) {
-        typedef SEXP(*Ptr_populate_env_symbol)(SEXP,SEXP,SEXP,SEXP);
+    inline Environment populate_env_symbol(Environment env, CharacterVector names, List fun_and_payload) {
+        typedef SEXP(*Ptr_populate_env_symbol)(SEXP,SEXP,SEXP);
         static Ptr_populate_env_symbol p_populate_env_symbol = NULL;
         if (p_populate_env_symbol == NULL) {
-            validateSignature("Environment(*populate_env_symbol)(Environment,CharacterVector,bindrcpp::GETTER_FUNC_SYMBOL,bindrcpp::PAYLOAD)");
+            validateSignature("Environment(*populate_env_symbol)(Environment,CharacterVector,List)");
             p_populate_env_symbol = (Ptr_populate_env_symbol)R_GetCCallable("bindrcpp", "bindrcpp_populate_env_symbol");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_populate_env_symbol(Rcpp::wrap(env), Rcpp::wrap(names), Rcpp::wrap(fun), Rcpp::wrap(payload));
+            rcpp_result_gen = p_populate_env_symbol(Rcpp::wrap(env), Rcpp::wrap(names), Rcpp::wrap(fun_and_payload));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -15,7 +15,7 @@ struct PAYLOAD {
     LOG_VERBOSE << this << "\n";
   }
   explicit PAYLOAD(void* p_) : p(p_) {
-    LOG_VERBOSE << "PAYLOAD(\", this, \")\n";
+    LOG_VERBOSE << "PAYLOAD(", this, ")\n";
   }
   ~PAYLOAD() {
     LOG_VERBOSE << "~PAYLOAD(", this, ")\n";

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -7,7 +7,7 @@
 
 namespace bindrcpp {
 
-struct PAYLOAD { void* p; explicit PAYLOAD(void* p_) : p(p_) { std::cerr << "PAYLOAD()\n"; }; ~PAYLOAD() { std::cerr << "~PAYLOAD()\n"; } };
+struct PAYLOAD { void* p; explicit PAYLOAD(void* p_) : p(p_) { LOG_VERBOSE << "PAYLOAD()\n"; }; ~PAYLOAD() { LOG_VERBOSE << "~PAYLOAD()\n"; } };
 typedef SEXP (*GETTER_FUNC_STRING)(const Rcpp::String& name, bindrcpp::PAYLOAD payload);
 typedef SEXP (*GETTER_FUNC_SYMBOL)(const Rcpp::Symbol& name, bindrcpp::PAYLOAD payload);
 
@@ -17,30 +17,30 @@ namespace Rcpp {
   using namespace bindrcpp;
 
   template <> inline SEXP wrap(const PAYLOAD& payload) {
-    std::cerr << "wrap(PAYLOAD)\n";
+    LOG_VERBOSE << "wrap(PAYLOAD)\n";
     return List::create(XPtr<PAYLOAD>(new PAYLOAD(payload)));
   }
   template <> inline SEXP wrap(const GETTER_FUNC_STRING& fun) {
-    std::cerr << "wrap(GETTER_FUNC_STRING)\n";
+    LOG_VERBOSE << "wrap(GETTER_FUNC_STRING)\n";
     return List::create(XPtr<GETTER_FUNC_STRING>(new GETTER_FUNC_STRING(fun)));
   }
   template <> inline SEXP wrap(const GETTER_FUNC_SYMBOL& fun) {
-    std::cerr << "wrap(GETTER_FUNC_SYMBOL)\n";
+    LOG_VERBOSE << "wrap(GETTER_FUNC_SYMBOL)\n";
     return List::create(XPtr<GETTER_FUNC_SYMBOL>(new GETTER_FUNC_SYMBOL(fun)));
   }
   template <> inline PAYLOAD as(SEXP x) {
     List xl = x;
-    std::cerr << "PAYLOAD as()\n";
+    LOG_VERBOSE << "PAYLOAD as()\n";
     return *(PAYLOAD*)R_ExternalPtrAddr(xl[0]);
   }
   template <> inline GETTER_FUNC_STRING as(SEXP x) {
     List xl = x;
-    std::cerr << "GETTER_FUNC_STRING as()\n";
+    LOG_VERBOSE << "GETTER_FUNC_STRING as()\n";
     return *(GETTER_FUNC_STRING*)R_ExternalPtrAddr(xl[0]);
   }
   template <> inline GETTER_FUNC_SYMBOL as(SEXP x) {
     List xl = x;
-    std::cerr << "GETTER_FUNC_SYMBOL as()\n";
+    LOG_VERBOSE << "GETTER_FUNC_SYMBOL as()\n";
     return *(GETTER_FUNC_SYMBOL*)R_ExternalPtrAddr(xl[0]);
   }
 }

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -24,10 +24,48 @@ struct PAYLOAD {
 typedef SEXP (*GETTER_FUNC_STRING)(const Rcpp::String& name, bindrcpp::PAYLOAD payload);
 typedef SEXP (*GETTER_FUNC_SYMBOL)(const Rcpp::Symbol& name, bindrcpp::PAYLOAD payload);
 
-}
+namespace internal {
+
+struct GETTER_FUNC_STRING_WRAP {
+  GETTER_FUNC_STRING p;
+
+  explicit GETTER_FUNC_STRING_WRAP(GETTER_FUNC_STRING p_) : p(p_) {
+    LOG_VERBOSE;
+  }
+
+  GETTER_FUNC_STRING_WRAP(const GETTER_FUNC_STRING_WRAP& p_) : p(p_.p) {
+    LOG_VERBOSE;
+  }
+
+  ~GETTER_FUNC_STRING_WRAP() {
+    LOG_VERBOSE;
+  }
+};
+
+struct GETTER_FUNC_SYMBOL_WRAP {
+  GETTER_FUNC_SYMBOL p;
+
+  explicit GETTER_FUNC_SYMBOL_WRAP(GETTER_FUNC_SYMBOL p_) : p(p_) {
+    LOG_VERBOSE;
+  }
+
+  GETTER_FUNC_SYMBOL_WRAP(const GETTER_FUNC_SYMBOL_WRAP& p_) : p(p_.p) {
+    LOG_VERBOSE;
+  }
+
+  ~GETTER_FUNC_SYMBOL_WRAP() {
+    LOG_VERBOSE;
+  }
+};
+
+} // namespace internal
+
+} // namespace bindrcpp
 
 namespace Rcpp {
   using namespace bindrcpp;
+
+  using namespace bindrcpp::internal;
 
   template <> inline SEXP wrap(const PAYLOAD& payload) {
     LOG_VERBOSE << "wrap(PAYLOAD)\n";
@@ -35,11 +73,15 @@ namespace Rcpp {
   }
   template <> inline SEXP wrap(const GETTER_FUNC_STRING& fun) {
     LOG_VERBOSE << "wrap(GETTER_FUNC_STRING)\n";
-    return List::create(XPtr<GETTER_FUNC_STRING>(new GETTER_FUNC_STRING(fun)));
+    SEXP ret = List::create(XPtr<GETTER_FUNC_STRING_WRAP>(new GETTER_FUNC_STRING_WRAP(fun)));
+    LOG_VERBOSE << "wrap(GETTER_FUNC_STRING) done\n";
+    return ret;
   }
   template <> inline SEXP wrap(const GETTER_FUNC_SYMBOL& fun) {
     LOG_VERBOSE << "wrap(GETTER_FUNC_SYMBOL)\n";
-    return List::create(XPtr<GETTER_FUNC_SYMBOL>(new GETTER_FUNC_SYMBOL(fun)));
+    SEXP ret = List::create(XPtr<GETTER_FUNC_SYMBOL_WRAP>(new GETTER_FUNC_SYMBOL_WRAP(fun)));
+    LOG_VERBOSE << "wrap(GETTER_FUNC_SYMBOL) done\n";
+    return ret;
   }
   template <> inline PAYLOAD as(SEXP x) {
     SEXP x0 = VECTOR_ELT(x, 0);
@@ -50,12 +92,14 @@ namespace Rcpp {
   template <> inline GETTER_FUNC_STRING as(SEXP x) {
     LOG_VERBOSE << "GETTER_FUNC_STRING as()\n";
     SEXP x0 = VECTOR_ELT(x, 0);
-    return *(GETTER_FUNC_STRING*)R_ExternalPtrAddr(x0);
+    GETTER_FUNC_STRING_WRAP* p = (GETTER_FUNC_STRING_WRAP*)R_ExternalPtrAddr(x0);
+    return p->p;
   }
   template <> inline GETTER_FUNC_SYMBOL as(SEXP x) {
     LOG_VERBOSE << "GETTER_FUNC_SYMBOL as()\n";
     SEXP x0 = VECTOR_ELT(x, 0);
-    return *(GETTER_FUNC_SYMBOL*)R_ExternalPtrAddr(x0);
+    GETTER_FUNC_SYMBOL_WRAP* p = (GETTER_FUNC_SYMBOL_WRAP*)R_ExternalPtrAddr(x0);
+    return p->p;
   }
 }
 

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -7,7 +7,7 @@
 
 namespace bindrcpp {
 
-struct PAYLOAD { void* p; explicit PAYLOAD(void* p_) : p(p_) { LOG_VERBOSE << "PAYLOAD()\n"; }; ~PAYLOAD() { LOG_VERBOSE << "~PAYLOAD()\n"; } };
+struct PAYLOAD { void* p; PAYLOAD() { LOG_VERBOSE; }; explicit PAYLOAD(void* p_) : p(p_) { LOG_VERBOSE << "PAYLOAD()\n"; }; ~PAYLOAD() { LOG_VERBOSE << "~PAYLOAD()\n"; } };
 typedef SEXP (*GETTER_FUNC_STRING)(const Rcpp::String& name, bindrcpp::PAYLOAD payload);
 typedef SEXP (*GETTER_FUNC_SYMBOL)(const Rcpp::Symbol& name, bindrcpp::PAYLOAD payload);
 

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -7,7 +7,7 @@
 
 namespace bindrcpp {
 
-struct PAYLOAD { void* p; explicit PAYLOAD(void* p_) : p(p_) { LOG_VERBOSE; }; ~PAYLOAD() { LOG_VERBOSE; } };
+struct PAYLOAD { void* p; explicit PAYLOAD(void* p_) : p(p_) { std::cerr << "PAYLOAD()\n"; }; ~PAYLOAD() { std::cerr << "~PAYLOAD()\n"; } };
 typedef SEXP (*GETTER_FUNC_STRING)(const Rcpp::String& name, bindrcpp::PAYLOAD payload);
 typedef SEXP (*GETTER_FUNC_SYMBOL)(const Rcpp::Symbol& name, bindrcpp::PAYLOAD payload);
 

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -29,19 +29,19 @@ namespace Rcpp {
     return List::create(XPtr<GETTER_FUNC_SYMBOL>(new GETTER_FUNC_SYMBOL(fun)));
   }
   template <> inline PAYLOAD as(SEXP x) {
-    List xl = x;
     LOG_VERBOSE << "PAYLOAD as()\n";
-    return *(PAYLOAD*)R_ExternalPtrAddr(xl[0]);
+    SEXP x0 = VECTOR_ELT(x, 0);
+    return *(PAYLOAD*)R_ExternalPtrAddr(x0);
   }
   template <> inline GETTER_FUNC_STRING as(SEXP x) {
-    List xl = x;
     LOG_VERBOSE << "GETTER_FUNC_STRING as()\n";
-    return *(GETTER_FUNC_STRING*)R_ExternalPtrAddr(xl[0]);
+    SEXP x0 = VECTOR_ELT(x, 0);
+    return *(GETTER_FUNC_STRING*)R_ExternalPtrAddr(x0);
   }
   template <> inline GETTER_FUNC_SYMBOL as(SEXP x) {
-    List xl = x;
     LOG_VERBOSE << "GETTER_FUNC_SYMBOL as()\n";
-    return *(GETTER_FUNC_SYMBOL*)R_ExternalPtrAddr(xl[0]);
+    SEXP x0 = VECTOR_ELT(x, 0);
+    return *(GETTER_FUNC_SYMBOL*)R_ExternalPtrAddr(x0);
   }
 }
 

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -7,7 +7,7 @@
 
 namespace bindrcpp {
 
-struct PAYLOAD { void* p; explicit PAYLOAD(void* p_) : p(p_) {}; };
+struct PAYLOAD { void* p; explicit PAYLOAD(void* p_) : p(p_) { LOG_VERBOSE; }; ~PAYLOAD() { LOG_VERBOSE; } };
 typedef SEXP (*GETTER_FUNC_STRING)(const Rcpp::String& name, bindrcpp::PAYLOAD payload);
 typedef SEXP (*GETTER_FUNC_SYMBOL)(const Rcpp::Symbol& name, bindrcpp::PAYLOAD payload);
 

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -12,13 +12,13 @@ namespace bindrcpp {
 struct PAYLOAD {
   void* p;
   PAYLOAD() {
-    LOG_VERBOSE;
+    LOG_VERBOSE << this << "\n";
   }
   explicit PAYLOAD(void* p_) : p(p_) {
-    LOG_VERBOSE << "PAYLOAD()\n";
+    LOG_VERBOSE << "PAYLOAD(\", this, \")\n";
   }
   ~PAYLOAD() {
-    LOG_VERBOSE << "~PAYLOAD()\n";
+    LOG_VERBOSE << "~PAYLOAD(", this, ")\n";
   }
 };
 typedef SEXP (*GETTER_FUNC_STRING)(const Rcpp::String& name, bindrcpp::PAYLOAD payload);
@@ -42,9 +42,10 @@ namespace Rcpp {
     return List::create(XPtr<GETTER_FUNC_SYMBOL>(new GETTER_FUNC_SYMBOL(fun)));
   }
   template <> inline PAYLOAD as(SEXP x) {
-    LOG_VERBOSE << "PAYLOAD as()\n";
     SEXP x0 = VECTOR_ELT(x, 0);
-    return *(PAYLOAD*)R_ExternalPtrAddr(x0);
+    PAYLOAD* p = (PAYLOAD*)R_ExternalPtrAddr(x0);
+    LOG_VERBOSE << "PAYLOAD as(" << p << ")\n";
+    return *p;
   }
   template <> inline GETTER_FUNC_STRING as(SEXP x) {
     LOG_VERBOSE << "GETTER_FUNC_STRING as()\n";

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -5,9 +5,22 @@
 
 #include <Rcpp.h>
 
+#include <plogr.h>
+
 namespace bindrcpp {
 
-struct PAYLOAD { void* p; PAYLOAD() { LOG_VERBOSE; }; explicit PAYLOAD(void* p_) : p(p_) { LOG_VERBOSE << "PAYLOAD()\n"; }; ~PAYLOAD() { LOG_VERBOSE << "~PAYLOAD()\n"; } };
+struct PAYLOAD {
+  void* p;
+  PAYLOAD() {
+    LOG_VERBOSE;
+  }
+  explicit PAYLOAD(void* p_) : p(p_) {
+    LOG_VERBOSE << "PAYLOAD()\n";
+  }
+  ~PAYLOAD() {
+    LOG_VERBOSE << "~PAYLOAD()\n";
+  }
+};
 typedef SEXP (*GETTER_FUNC_STRING)(const Rcpp::String& name, bindrcpp::PAYLOAD payload);
 typedef SEXP (*GETTER_FUNC_SYMBOL)(const Rcpp::Symbol& name, bindrcpp::PAYLOAD payload);
 

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -27,18 +27,15 @@ namespace Rcpp {
   }
   template <> inline PAYLOAD as(SEXP x) {
     List xl = x;
-    XPtr<PAYLOAD> xpayload(static_cast<SEXP>(xl[0]));
-    return *xpayload.get();
+    return *(PAYLOAD*)R_ExternalPtrAddr(xl[0]);
   }
   template <> inline GETTER_FUNC_STRING as(SEXP x) {
     List xl = x;
-    XPtr<GETTER_FUNC_STRING> xfun(static_cast<SEXP>(xl[0]));
-    return *xfun.get();
+    return *(GETTER_FUNC_STRING*)R_ExternalPtrAddr(xl[0]);
   }
   template <> inline GETTER_FUNC_SYMBOL as(SEXP x) {
     List xl = x;
-    XPtr<GETTER_FUNC_SYMBOL> xfun(static_cast<SEXP>(xl[0]));
-    return *xfun.get();
+    return *(GETTER_FUNC_SYMBOL*)R_ExternalPtrAddr(xl[0]);
   }
 }
 

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -17,24 +17,30 @@ namespace Rcpp {
   using namespace bindrcpp;
 
   template <> inline SEXP wrap(const PAYLOAD& payload) {
+    std::cerr << "wrap(PAYLOAD)\n";
     return List::create(XPtr<PAYLOAD>(new PAYLOAD(payload)));
   }
   template <> inline SEXP wrap(const GETTER_FUNC_STRING& fun) {
+    std::cerr << "wrap(GETTER_FUNC_STRING)\n";
     return List::create(XPtr<GETTER_FUNC_STRING>(new GETTER_FUNC_STRING(fun)));
   }
   template <> inline SEXP wrap(const GETTER_FUNC_SYMBOL& fun) {
+    std::cerr << "wrap(GETTER_FUNC_SYMBOL)\n";
     return List::create(XPtr<GETTER_FUNC_SYMBOL>(new GETTER_FUNC_SYMBOL(fun)));
   }
   template <> inline PAYLOAD as(SEXP x) {
     List xl = x;
+    std::cerr << "PAYLOAD as()\n";
     return *(PAYLOAD*)R_ExternalPtrAddr(xl[0]);
   }
   template <> inline GETTER_FUNC_STRING as(SEXP x) {
     List xl = x;
+    std::cerr << "GETTER_FUNC_STRING as()\n";
     return *(GETTER_FUNC_STRING*)R_ExternalPtrAddr(xl[0]);
   }
   template <> inline GETTER_FUNC_SYMBOL as(SEXP x) {
     List xl = x;
+    std::cerr << "GETTER_FUNC_SYMBOL as()\n";
     return *(GETTER_FUNC_SYMBOL*)R_ExternalPtrAddr(xl[0]);
   }
 }

--- a/inst/include/bindrcpp_types.h
+++ b/inst/include/bindrcpp_types.h
@@ -15,10 +15,10 @@ struct PAYLOAD {
     LOG_VERBOSE << this << "\n";
   }
   explicit PAYLOAD(void* p_) : p(p_) {
-    LOG_VERBOSE << "PAYLOAD(", this, ")\n";
+    LOG_VERBOSE << "PAYLOAD(" << this << ", " << p << ")\n";
   }
   ~PAYLOAD() {
-    LOG_VERBOSE << "~PAYLOAD(", this, ")\n";
+    LOG_VERBOSE << "~PAYLOAD(" << this << ", " << p << ")\n";
   }
 };
 typedef SEXP (*GETTER_FUNC_STRING)(const Rcpp::String& name, bindrcpp::PAYLOAD payload);
@@ -44,7 +44,7 @@ namespace Rcpp {
   template <> inline PAYLOAD as(SEXP x) {
     SEXP x0 = VECTOR_ELT(x, 0);
     PAYLOAD* p = (PAYLOAD*)R_ExternalPtrAddr(x0);
-    LOG_VERBOSE << "PAYLOAD as(" << p << ")\n";
+    LOG_VERBOSE << "PAYLOAD as(" << p << ", " << p->p << ")\n";
     return *p;
   }
   template <> inline GETTER_FUNC_STRING as(SEXP x) {

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,12 +1,1 @@
 PKG_CPPFLAGS = -I../inst/include -I.
-
-all: $(SHLIB)
-
-# This file exists only for R CMD INSTALL, is created as empty file
-# for building from source archive
-Makevars.local:
-	touch "$@"
-include Makevars.local
-
-clean:
-	rm -f *.d

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,1 +1,1 @@
-PKG_CPPFLAGS = -I../inst/include -I.
+PKG_CPPFLAGS = -I../inst/include -I. -DPLOGR_ENABLE

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -210,3 +210,21 @@ RcppExport SEXP bindrcpp_RcppExport_registerCCallable() {
     R_RegisterCCallable("bindrcpp", "bindrcpp_RcppExport_validate", (DL_FUNC)bindrcpp_RcppExport_validate);
     return R_NilValue;
 }
+
+static const R_CallMethodDef CallEntries[] = {
+    {"bindrcpp_create_env_string_imp", (DL_FUNC) &bindrcpp_create_env_string_imp, 4},
+    {"bindrcpp_populate_env_string_imp", (DL_FUNC) &bindrcpp_populate_env_string_imp, 4},
+    {"bindrcpp_create_env_symbol_imp", (DL_FUNC) &bindrcpp_create_env_symbol_imp, 4},
+    {"bindrcpp_populate_env_symbol_imp", (DL_FUNC) &bindrcpp_populate_env_symbol_imp, 4},
+    {"bindrcpp_init_logging", (DL_FUNC) &bindrcpp_init_logging, 1},
+    {"bindrcpp_callback_string", (DL_FUNC) &bindrcpp_callback_string, 3},
+    {"bindrcpp_callback_symbol", (DL_FUNC) &bindrcpp_callback_symbol, 3},
+    {"bindrcpp_do_test_create_environment", (DL_FUNC) &bindrcpp_do_test_create_environment, 3},
+    {"bindrcpp_RcppExport_registerCCallable", (DL_FUNC) &bindrcpp_RcppExport_registerCCallable, 0},
+    {NULL, NULL, 0}
+};
+
+RcppExport void R_init_bindrcpp(DllInfo *dll) {
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -10,23 +10,22 @@
 using namespace Rcpp;
 
 // create_env_string_imp
-Environment create_env_string_imp(CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload, Environment enclos);
-static SEXP bindrcpp_create_env_string_imp_try(SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP, SEXP enclosSEXP) {
+Environment create_env_string_imp(CharacterVector names, List fun_and_payload, Environment enclos);
+static SEXP bindrcpp_create_env_string_imp_try(SEXP namesSEXP, SEXP fun_and_payloadSEXP, SEXP enclosSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< CharacterVector >::type names(namesSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::GETTER_FUNC_STRING >::type fun(funSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::PAYLOAD >::type payload(payloadSEXP);
+    Rcpp::traits::input_parameter< List >::type fun_and_payload(fun_and_payloadSEXP);
     Rcpp::traits::input_parameter< Environment >::type enclos(enclosSEXP);
-    rcpp_result_gen = Rcpp::wrap(create_env_string_imp(names, fun, payload, enclos));
+    rcpp_result_gen = Rcpp::wrap(create_env_string_imp(names, fun_and_payload, enclos));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP bindrcpp_create_env_string_imp(SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP, SEXP enclosSEXP) {
+RcppExport SEXP bindrcpp_create_env_string_imp(SEXP namesSEXP, SEXP fun_and_payloadSEXP, SEXP enclosSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(bindrcpp_create_env_string_imp_try(namesSEXP, funSEXP, payloadSEXP, enclosSEXP));
+        rcpp_result_gen = PROTECT(bindrcpp_create_env_string_imp_try(namesSEXP, fun_and_payloadSEXP, enclosSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -43,23 +42,22 @@ RcppExport SEXP bindrcpp_create_env_string_imp(SEXP namesSEXP, SEXP funSEXP, SEX
     return rcpp_result_gen;
 }
 // populate_env_string_imp
-Environment populate_env_string_imp(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload);
-static SEXP bindrcpp_populate_env_string_imp_try(SEXP envSEXP, SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP) {
+Environment populate_env_string_imp(Environment env, CharacterVector names, List fun_and_payload);
+static SEXP bindrcpp_populate_env_string_imp_try(SEXP envSEXP, SEXP namesSEXP, SEXP fun_and_payloadSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< Environment >::type env(envSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type names(namesSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::GETTER_FUNC_STRING >::type fun(funSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::PAYLOAD >::type payload(payloadSEXP);
-    rcpp_result_gen = Rcpp::wrap(populate_env_string_imp(env, names, fun, payload));
+    Rcpp::traits::input_parameter< List >::type fun_and_payload(fun_and_payloadSEXP);
+    rcpp_result_gen = Rcpp::wrap(populate_env_string_imp(env, names, fun_and_payload));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP bindrcpp_populate_env_string_imp(SEXP envSEXP, SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP) {
+RcppExport SEXP bindrcpp_populate_env_string_imp(SEXP envSEXP, SEXP namesSEXP, SEXP fun_and_payloadSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(bindrcpp_populate_env_string_imp_try(envSEXP, namesSEXP, funSEXP, payloadSEXP));
+        rcpp_result_gen = PROTECT(bindrcpp_populate_env_string_imp_try(envSEXP, namesSEXP, fun_and_payloadSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -76,23 +74,22 @@ RcppExport SEXP bindrcpp_populate_env_string_imp(SEXP envSEXP, SEXP namesSEXP, S
     return rcpp_result_gen;
 }
 // create_env_symbol_imp
-Environment create_env_symbol_imp(CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload, Environment enclos);
-static SEXP bindrcpp_create_env_symbol_imp_try(SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP, SEXP enclosSEXP) {
+Environment create_env_symbol_imp(CharacterVector names, List fun_and_payload, Environment enclos);
+static SEXP bindrcpp_create_env_symbol_imp_try(SEXP namesSEXP, SEXP fun_and_payloadSEXP, SEXP enclosSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< CharacterVector >::type names(namesSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::GETTER_FUNC_SYMBOL >::type fun(funSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::PAYLOAD >::type payload(payloadSEXP);
+    Rcpp::traits::input_parameter< List >::type fun_and_payload(fun_and_payloadSEXP);
     Rcpp::traits::input_parameter< Environment >::type enclos(enclosSEXP);
-    rcpp_result_gen = Rcpp::wrap(create_env_symbol_imp(names, fun, payload, enclos));
+    rcpp_result_gen = Rcpp::wrap(create_env_symbol_imp(names, fun_and_payload, enclos));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP bindrcpp_create_env_symbol_imp(SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP, SEXP enclosSEXP) {
+RcppExport SEXP bindrcpp_create_env_symbol_imp(SEXP namesSEXP, SEXP fun_and_payloadSEXP, SEXP enclosSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(bindrcpp_create_env_symbol_imp_try(namesSEXP, funSEXP, payloadSEXP, enclosSEXP));
+        rcpp_result_gen = PROTECT(bindrcpp_create_env_symbol_imp_try(namesSEXP, fun_and_payloadSEXP, enclosSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -109,23 +106,22 @@ RcppExport SEXP bindrcpp_create_env_symbol_imp(SEXP namesSEXP, SEXP funSEXP, SEX
     return rcpp_result_gen;
 }
 // populate_env_symbol_imp
-Environment populate_env_symbol_imp(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload);
-static SEXP bindrcpp_populate_env_symbol_imp_try(SEXP envSEXP, SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP) {
+Environment populate_env_symbol_imp(Environment env, CharacterVector names, List fun_and_payload);
+static SEXP bindrcpp_populate_env_symbol_imp_try(SEXP envSEXP, SEXP namesSEXP, SEXP fun_and_payloadSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< Environment >::type env(envSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type names(namesSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::GETTER_FUNC_SYMBOL >::type fun(funSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::PAYLOAD >::type payload(payloadSEXP);
-    rcpp_result_gen = Rcpp::wrap(populate_env_symbol_imp(env, names, fun, payload));
+    Rcpp::traits::input_parameter< List >::type fun_and_payload(fun_and_payloadSEXP);
+    rcpp_result_gen = Rcpp::wrap(populate_env_symbol_imp(env, names, fun_and_payload));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP bindrcpp_populate_env_symbol_imp(SEXP envSEXP, SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP) {
+RcppExport SEXP bindrcpp_populate_env_symbol_imp(SEXP envSEXP, SEXP namesSEXP, SEXP fun_and_payloadSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(bindrcpp_populate_env_symbol_imp_try(envSEXP, namesSEXP, funSEXP, payloadSEXP));
+        rcpp_result_gen = PROTECT(bindrcpp_populate_env_symbol_imp_try(envSEXP, namesSEXP, fun_and_payloadSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -191,10 +187,10 @@ END_RCPP
 static int bindrcpp_RcppExport_validate(const char* sig) { 
     static std::set<std::string> signatures;
     if (signatures.empty()) {
-        signatures.insert("Environment(*create_env_string)(CharacterVector,bindrcpp::GETTER_FUNC_STRING,bindrcpp::PAYLOAD,Environment)");
-        signatures.insert("Environment(*populate_env_string)(Environment,CharacterVector,bindrcpp::GETTER_FUNC_STRING,bindrcpp::PAYLOAD)");
-        signatures.insert("Environment(*create_env_symbol)(CharacterVector,bindrcpp::GETTER_FUNC_SYMBOL,bindrcpp::PAYLOAD,Environment)");
-        signatures.insert("Environment(*populate_env_symbol)(Environment,CharacterVector,bindrcpp::GETTER_FUNC_SYMBOL,bindrcpp::PAYLOAD)");
+        signatures.insert("Environment(*create_env_string)(CharacterVector,List,Environment)");
+        signatures.insert("Environment(*populate_env_string)(Environment,CharacterVector,List)");
+        signatures.insert("Environment(*create_env_symbol)(CharacterVector,List,Environment)");
+        signatures.insert("Environment(*populate_env_symbol)(Environment,CharacterVector,List)");
     }
     return signatures.find(sig) != signatures.end();
 }
@@ -210,10 +206,10 @@ RcppExport SEXP bindrcpp_RcppExport_registerCCallable() {
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"bindrcpp_create_env_string_imp", (DL_FUNC) &bindrcpp_create_env_string_imp, 4},
-    {"bindrcpp_populate_env_string_imp", (DL_FUNC) &bindrcpp_populate_env_string_imp, 4},
-    {"bindrcpp_create_env_symbol_imp", (DL_FUNC) &bindrcpp_create_env_symbol_imp, 4},
-    {"bindrcpp_populate_env_symbol_imp", (DL_FUNC) &bindrcpp_populate_env_symbol_imp, 4},
+    {"bindrcpp_create_env_string_imp", (DL_FUNC) &bindrcpp_create_env_string_imp, 3},
+    {"bindrcpp_populate_env_string_imp", (DL_FUNC) &bindrcpp_populate_env_string_imp, 3},
+    {"bindrcpp_create_env_symbol_imp", (DL_FUNC) &bindrcpp_create_env_symbol_imp, 3},
+    {"bindrcpp_populate_env_symbol_imp", (DL_FUNC) &bindrcpp_populate_env_symbol_imp, 3},
     {"bindrcpp_init_logging", (DL_FUNC) &bindrcpp_init_logging, 1},
     {"bindrcpp_callback_string", (DL_FUNC) &bindrcpp_callback_string, 2},
     {"bindrcpp_callback_symbol", (DL_FUNC) &bindrcpp_callback_symbol, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -10,22 +10,23 @@
 using namespace Rcpp;
 
 // create_env_string_imp
-Environment create_env_string_imp(CharacterVector names, List fun_and_payload, Environment enclos);
-static SEXP bindrcpp_create_env_string_imp_try(SEXP namesSEXP, SEXP fun_and_payloadSEXP, SEXP enclosSEXP) {
+Environment create_env_string_imp(CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload, Environment enclos);
+static SEXP bindrcpp_create_env_string_imp_try(SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP, SEXP enclosSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< CharacterVector >::type names(namesSEXP);
-    Rcpp::traits::input_parameter< List >::type fun_and_payload(fun_and_payloadSEXP);
+    Rcpp::traits::input_parameter< bindrcpp::GETTER_FUNC_STRING >::type fun(funSEXP);
+    Rcpp::traits::input_parameter< bindrcpp::PAYLOAD >::type payload(payloadSEXP);
     Rcpp::traits::input_parameter< Environment >::type enclos(enclosSEXP);
-    rcpp_result_gen = Rcpp::wrap(create_env_string_imp(names, fun_and_payload, enclos));
+    rcpp_result_gen = Rcpp::wrap(create_env_string_imp(names, fun, payload, enclos));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP bindrcpp_create_env_string_imp(SEXP namesSEXP, SEXP fun_and_payloadSEXP, SEXP enclosSEXP) {
+RcppExport SEXP bindrcpp_create_env_string_imp(SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP, SEXP enclosSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(bindrcpp_create_env_string_imp_try(namesSEXP, fun_and_payloadSEXP, enclosSEXP));
+        rcpp_result_gen = PROTECT(bindrcpp_create_env_string_imp_try(namesSEXP, funSEXP, payloadSEXP, enclosSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -42,22 +43,23 @@ RcppExport SEXP bindrcpp_create_env_string_imp(SEXP namesSEXP, SEXP fun_and_payl
     return rcpp_result_gen;
 }
 // populate_env_string_imp
-Environment populate_env_string_imp(Environment env, CharacterVector names, List fun_and_payload);
-static SEXP bindrcpp_populate_env_string_imp_try(SEXP envSEXP, SEXP namesSEXP, SEXP fun_and_payloadSEXP) {
+Environment populate_env_string_imp(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload);
+static SEXP bindrcpp_populate_env_string_imp_try(SEXP envSEXP, SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< Environment >::type env(envSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type names(namesSEXP);
-    Rcpp::traits::input_parameter< List >::type fun_and_payload(fun_and_payloadSEXP);
-    rcpp_result_gen = Rcpp::wrap(populate_env_string_imp(env, names, fun_and_payload));
+    Rcpp::traits::input_parameter< bindrcpp::GETTER_FUNC_STRING >::type fun(funSEXP);
+    Rcpp::traits::input_parameter< bindrcpp::PAYLOAD >::type payload(payloadSEXP);
+    rcpp_result_gen = Rcpp::wrap(populate_env_string_imp(env, names, fun, payload));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP bindrcpp_populate_env_string_imp(SEXP envSEXP, SEXP namesSEXP, SEXP fun_and_payloadSEXP) {
+RcppExport SEXP bindrcpp_populate_env_string_imp(SEXP envSEXP, SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(bindrcpp_populate_env_string_imp_try(envSEXP, namesSEXP, fun_and_payloadSEXP));
+        rcpp_result_gen = PROTECT(bindrcpp_populate_env_string_imp_try(envSEXP, namesSEXP, funSEXP, payloadSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -74,22 +76,23 @@ RcppExport SEXP bindrcpp_populate_env_string_imp(SEXP envSEXP, SEXP namesSEXP, S
     return rcpp_result_gen;
 }
 // create_env_symbol_imp
-Environment create_env_symbol_imp(CharacterVector names, List fun_and_payload, Environment enclos);
-static SEXP bindrcpp_create_env_symbol_imp_try(SEXP namesSEXP, SEXP fun_and_payloadSEXP, SEXP enclosSEXP) {
+Environment create_env_symbol_imp(CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload, Environment enclos);
+static SEXP bindrcpp_create_env_symbol_imp_try(SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP, SEXP enclosSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< CharacterVector >::type names(namesSEXP);
-    Rcpp::traits::input_parameter< List >::type fun_and_payload(fun_and_payloadSEXP);
+    Rcpp::traits::input_parameter< bindrcpp::GETTER_FUNC_SYMBOL >::type fun(funSEXP);
+    Rcpp::traits::input_parameter< bindrcpp::PAYLOAD >::type payload(payloadSEXP);
     Rcpp::traits::input_parameter< Environment >::type enclos(enclosSEXP);
-    rcpp_result_gen = Rcpp::wrap(create_env_symbol_imp(names, fun_and_payload, enclos));
+    rcpp_result_gen = Rcpp::wrap(create_env_symbol_imp(names, fun, payload, enclos));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP bindrcpp_create_env_symbol_imp(SEXP namesSEXP, SEXP fun_and_payloadSEXP, SEXP enclosSEXP) {
+RcppExport SEXP bindrcpp_create_env_symbol_imp(SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP, SEXP enclosSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(bindrcpp_create_env_symbol_imp_try(namesSEXP, fun_and_payloadSEXP, enclosSEXP));
+        rcpp_result_gen = PROTECT(bindrcpp_create_env_symbol_imp_try(namesSEXP, funSEXP, payloadSEXP, enclosSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -106,22 +109,23 @@ RcppExport SEXP bindrcpp_create_env_symbol_imp(SEXP namesSEXP, SEXP fun_and_payl
     return rcpp_result_gen;
 }
 // populate_env_symbol_imp
-Environment populate_env_symbol_imp(Environment env, CharacterVector names, List fun_and_payload);
-static SEXP bindrcpp_populate_env_symbol_imp_try(SEXP envSEXP, SEXP namesSEXP, SEXP fun_and_payloadSEXP) {
+Environment populate_env_symbol_imp(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload);
+static SEXP bindrcpp_populate_env_symbol_imp_try(SEXP envSEXP, SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< Environment >::type env(envSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type names(namesSEXP);
-    Rcpp::traits::input_parameter< List >::type fun_and_payload(fun_and_payloadSEXP);
-    rcpp_result_gen = Rcpp::wrap(populate_env_symbol_imp(env, names, fun_and_payload));
+    Rcpp::traits::input_parameter< bindrcpp::GETTER_FUNC_SYMBOL >::type fun(funSEXP);
+    Rcpp::traits::input_parameter< bindrcpp::PAYLOAD >::type payload(payloadSEXP);
+    rcpp_result_gen = Rcpp::wrap(populate_env_symbol_imp(env, names, fun, payload));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP bindrcpp_populate_env_symbol_imp(SEXP envSEXP, SEXP namesSEXP, SEXP fun_and_payloadSEXP) {
+RcppExport SEXP bindrcpp_populate_env_symbol_imp(SEXP envSEXP, SEXP namesSEXP, SEXP funSEXP, SEXP payloadSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(bindrcpp_populate_env_symbol_imp_try(envSEXP, namesSEXP, fun_and_payloadSEXP));
+        rcpp_result_gen = PROTECT(bindrcpp_populate_env_symbol_imp_try(envSEXP, namesSEXP, funSEXP, payloadSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -187,10 +191,10 @@ END_RCPP
 static int bindrcpp_RcppExport_validate(const char* sig) { 
     static std::set<std::string> signatures;
     if (signatures.empty()) {
-        signatures.insert("Environment(*create_env_string)(CharacterVector,List,Environment)");
-        signatures.insert("Environment(*populate_env_string)(Environment,CharacterVector,List)");
-        signatures.insert("Environment(*create_env_symbol)(CharacterVector,List,Environment)");
-        signatures.insert("Environment(*populate_env_symbol)(Environment,CharacterVector,List)");
+        signatures.insert("Environment(*create_env_string)(CharacterVector,bindrcpp::GETTER_FUNC_STRING,bindrcpp::PAYLOAD,Environment)");
+        signatures.insert("Environment(*populate_env_string)(Environment,CharacterVector,bindrcpp::GETTER_FUNC_STRING,bindrcpp::PAYLOAD)");
+        signatures.insert("Environment(*create_env_symbol)(CharacterVector,bindrcpp::GETTER_FUNC_SYMBOL,bindrcpp::PAYLOAD,Environment)");
+        signatures.insert("Environment(*populate_env_symbol)(Environment,CharacterVector,bindrcpp::GETTER_FUNC_SYMBOL,bindrcpp::PAYLOAD)");
     }
     return signatures.find(sig) != signatures.end();
 }
@@ -206,10 +210,10 @@ RcppExport SEXP bindrcpp_RcppExport_registerCCallable() {
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"bindrcpp_create_env_string_imp", (DL_FUNC) &bindrcpp_create_env_string_imp, 3},
-    {"bindrcpp_populate_env_string_imp", (DL_FUNC) &bindrcpp_populate_env_string_imp, 3},
-    {"bindrcpp_create_env_symbol_imp", (DL_FUNC) &bindrcpp_create_env_symbol_imp, 3},
-    {"bindrcpp_populate_env_symbol_imp", (DL_FUNC) &bindrcpp_populate_env_symbol_imp, 3},
+    {"bindrcpp_create_env_string_imp", (DL_FUNC) &bindrcpp_create_env_string_imp, 4},
+    {"bindrcpp_populate_env_string_imp", (DL_FUNC) &bindrcpp_populate_env_string_imp, 4},
+    {"bindrcpp_create_env_symbol_imp", (DL_FUNC) &bindrcpp_create_env_symbol_imp, 4},
+    {"bindrcpp_populate_env_symbol_imp", (DL_FUNC) &bindrcpp_populate_env_symbol_imp, 4},
     {"bindrcpp_init_logging", (DL_FUNC) &bindrcpp_init_logging, 1},
     {"bindrcpp_callback_string", (DL_FUNC) &bindrcpp_callback_string, 2},
     {"bindrcpp_callback_symbol", (DL_FUNC) &bindrcpp_callback_symbol, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -152,26 +152,24 @@ BEGIN_RCPP
 END_RCPP
 }
 // callback_string
-SEXP callback_string(Symbol name, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload);
-RcppExport SEXP bindrcpp_callback_string(SEXP nameSEXP, SEXP funSEXP, SEXP payloadSEXP) {
+SEXP callback_string(Symbol name, List fun_and_payload);
+RcppExport SEXP bindrcpp_callback_string(SEXP nameSEXP, SEXP fun_and_payloadSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< Symbol >::type name(nameSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::GETTER_FUNC_STRING >::type fun(funSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::PAYLOAD >::type payload(payloadSEXP);
-    rcpp_result_gen = Rcpp::wrap(callback_string(name, fun, payload));
+    Rcpp::traits::input_parameter< List >::type fun_and_payload(fun_and_payloadSEXP);
+    rcpp_result_gen = Rcpp::wrap(callback_string(name, fun_and_payload));
     return rcpp_result_gen;
 END_RCPP
 }
 // callback_symbol
-SEXP callback_symbol(Symbol name, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload);
-RcppExport SEXP bindrcpp_callback_symbol(SEXP nameSEXP, SEXP funSEXP, SEXP payloadSEXP) {
+SEXP callback_symbol(Symbol name, List fun_and_payload);
+RcppExport SEXP bindrcpp_callback_symbol(SEXP nameSEXP, SEXP fun_and_payloadSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< Symbol >::type name(nameSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::GETTER_FUNC_SYMBOL >::type fun(funSEXP);
-    Rcpp::traits::input_parameter< bindrcpp::PAYLOAD >::type payload(payloadSEXP);
-    rcpp_result_gen = Rcpp::wrap(callback_symbol(name, fun, payload));
+    Rcpp::traits::input_parameter< List >::type fun_and_payload(fun_and_payloadSEXP);
+    rcpp_result_gen = Rcpp::wrap(callback_symbol(name, fun_and_payload));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -217,8 +215,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"bindrcpp_create_env_symbol_imp", (DL_FUNC) &bindrcpp_create_env_symbol_imp, 4},
     {"bindrcpp_populate_env_symbol_imp", (DL_FUNC) &bindrcpp_populate_env_symbol_imp, 4},
     {"bindrcpp_init_logging", (DL_FUNC) &bindrcpp_init_logging, 1},
-    {"bindrcpp_callback_string", (DL_FUNC) &bindrcpp_callback_string, 3},
-    {"bindrcpp_callback_symbol", (DL_FUNC) &bindrcpp_callback_symbol, 3},
+    {"bindrcpp_callback_string", (DL_FUNC) &bindrcpp_callback_string, 2},
+    {"bindrcpp_callback_symbol", (DL_FUNC) &bindrcpp_callback_symbol, 2},
     {"bindrcpp_do_test_create_environment", (DL_FUNC) &bindrcpp_do_test_create_environment, 3},
     {"bindrcpp_RcppExport_registerCCallable", (DL_FUNC) &bindrcpp_RcppExport_registerCCallable, 0},
     {NULL, NULL, 0}

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -14,32 +14,36 @@ Function R_callback_symbol("callback_symbol", pkg_env);
 
 // [[Rcpp::interfaces(cpp)]]
 // [[Rcpp::export(create_env_string)]]
-Environment create_env_string_imp(CharacterVector names, List fun_and_payload, Environment enclos) {
+Environment create_env_string_imp(CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload, Environment enclos) {
   using namespace bindrcpp;
 
-  return R_create_env(names, R_callback_string, fun_and_payload, _[".enclos"] = enclos);
+  LOG_VERBOSE << payload.p;
+  return R_create_env(names, R_callback_string, List::create(fun, payload), _[".enclos"] = enclos);
 }
 
 // [[Rcpp::interfaces(cpp)]]
 // [[Rcpp::export(populate_env_string)]]
-Environment populate_env_string_imp(Environment env, CharacterVector names, List fun_and_payload) {
+Environment populate_env_string_imp(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload) {
   using namespace bindrcpp;
 
-  return R_populate_env(env, names, R_callback_string, fun_and_payload);
+  LOG_VERBOSE << payload.p;
+  return R_populate_env(env, names, R_callback_string, List::create(fun, payload));
 }
 
 // [[Rcpp::interfaces(cpp)]]
 // [[Rcpp::export(create_env_symbol)]]
-Environment create_env_symbol_imp(CharacterVector names, List fun_and_payload, Environment enclos) {
+Environment create_env_symbol_imp(CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload, Environment enclos) {
   using namespace bindrcpp;
 
-  return R_create_env(names, R_callback_symbol, fun_and_payload, _[".enclos"] = enclos);
+  LOG_VERBOSE << payload.p;
+  return R_create_env(names, R_callback_symbol, List::create(fun, payload), _[".enclos"] = enclos);
 }
 
 // [[Rcpp::interfaces(cpp)]]
 // [[Rcpp::export(populate_env_symbol)]]
-Environment populate_env_symbol_imp(Environment env, CharacterVector names, List fun_and_payload) {
+Environment populate_env_symbol_imp(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload) {
   using namespace bindrcpp;
 
-  return R_populate_env(env, names, R_callback_symbol, fun_and_payload);
+  LOG_VERBOSE << payload.p;
+  return R_populate_env(env, names, R_callback_symbol, List::create(fun, payload));
 }

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -14,36 +14,32 @@ Function R_callback_symbol("callback_symbol", pkg_env);
 
 // [[Rcpp::interfaces(cpp)]]
 // [[Rcpp::export(create_env_string)]]
-Environment create_env_string_imp(CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload, Environment enclos) {
+Environment create_env_string_imp(CharacterVector names, List fun_and_payload, Environment enclos) {
   using namespace bindrcpp;
 
-  LOG_VERBOSE << payload.p;
-  return R_create_env(names, R_callback_string, List::create(fun, payload), _[".enclos"] = enclos);
+  return R_create_env(names, R_callback_string, fun_and_payload, _[".enclos"] = enclos);
 }
 
 // [[Rcpp::interfaces(cpp)]]
 // [[Rcpp::export(populate_env_string)]]
-Environment populate_env_string_imp(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload) {
+Environment populate_env_string_imp(Environment env, CharacterVector names, List fun_and_payload) {
   using namespace bindrcpp;
 
-  LOG_VERBOSE << payload.p;
-  return R_populate_env(env, names, R_callback_string, List::create(fun, payload));
+  return R_populate_env(env, names, R_callback_string, fun_and_payload);
 }
 
 // [[Rcpp::interfaces(cpp)]]
 // [[Rcpp::export(create_env_symbol)]]
-Environment create_env_symbol_imp(CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload, Environment enclos) {
+Environment create_env_symbol_imp(CharacterVector names, List fun_and_payload, Environment enclos) {
   using namespace bindrcpp;
 
-  LOG_VERBOSE << payload.p;
-  return R_create_env(names, R_callback_symbol, List::create(fun, payload), _[".enclos"] = enclos);
+  return R_create_env(names, R_callback_symbol, fun_and_payload, _[".enclos"] = enclos);
 }
 
 // [[Rcpp::interfaces(cpp)]]
 // [[Rcpp::export(populate_env_symbol)]]
-Environment populate_env_symbol_imp(Environment env, CharacterVector names, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload) {
+Environment populate_env_symbol_imp(Environment env, CharacterVector names, List fun_and_payload) {
   using namespace bindrcpp;
 
-  LOG_VERBOSE << payload.p;
-  return R_populate_env(env, names, R_callback_symbol, List::create(fun, payload));
+  return R_populate_env(env, names, R_callback_symbol, fun_and_payload);
 }

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -18,7 +18,7 @@ Environment create_env_string_imp(CharacterVector names, bindrcpp::GETTER_FUNC_S
   using namespace bindrcpp;
 
   LOG_VERBOSE << payload.p;
-  return R_create_env(names, R_callback_string, fun, payload, _[".enclos"] = enclos);
+  return R_create_env(names, R_callback_string, List::create(fun, payload), _[".enclos"] = enclos);
 }
 
 // [[Rcpp::interfaces(cpp)]]
@@ -27,7 +27,7 @@ Environment populate_env_string_imp(Environment env, CharacterVector names, bind
   using namespace bindrcpp;
 
   LOG_VERBOSE << payload.p;
-  return R_populate_env(env, names, R_callback_string, fun, payload);
+  return R_populate_env(env, names, R_callback_string, List::create(fun, payload));
 }
 
 // [[Rcpp::interfaces(cpp)]]
@@ -36,7 +36,7 @@ Environment create_env_symbol_imp(CharacterVector names, bindrcpp::GETTER_FUNC_S
   using namespace bindrcpp;
 
   LOG_VERBOSE << payload.p;
-  return R_create_env(names, R_callback_symbol, fun, payload, _[".enclos"] = enclos);
+  return R_create_env(names, R_callback_symbol, List::create(fun, payload), _[".enclos"] = enclos);
 }
 
 // [[Rcpp::interfaces(cpp)]]
@@ -45,5 +45,5 @@ Environment populate_env_symbol_imp(Environment env, CharacterVector names, bind
   using namespace bindrcpp;
 
   LOG_VERBOSE << payload.p;
-  return R_populate_env(env, names, R_callback_symbol, fun, payload);
+  return R_populate_env(env, names, R_callback_symbol, List::create(fun, payload));
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -12,7 +12,10 @@ using namespace Rcpp;
 using namespace bindrcpp;
 
 // [[Rcpp::export(rng = FALSE)]]
-SEXP callback_string(Symbol name, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PAYLOAD payload) {
+SEXP callback_string(Symbol name, List fun_and_payload) {
+  bindrcpp::GETTER_FUNC_STRING fun = fun_and_payload[0];
+  bindrcpp::PAYLOAD payload = fun_and_payload[1];
+
   LOG_VERBOSE << type2name(name);
   LOG_VERBOSE << payload.p;
 
@@ -23,7 +26,10 @@ SEXP callback_string(Symbol name, bindrcpp::GETTER_FUNC_STRING fun, bindrcpp::PA
 }
 
 // [[Rcpp::export(rng = FALSE)]]
-SEXP callback_symbol(Symbol name, bindrcpp::GETTER_FUNC_SYMBOL fun, bindrcpp::PAYLOAD payload) {
+SEXP callback_symbol(Symbol name, List fun_and_payload) {
+  bindrcpp::GETTER_FUNC_SYMBOL fun = fun_and_payload[0];
+  bindrcpp::PAYLOAD payload = fun_and_payload[1];
+
   LOG_VERBOSE << type2name(name);
   LOG_VERBOSE << payload.p;
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -84,11 +84,11 @@ List do_test_create_environment(CharacterVector names, String xform, Environment
 
   if (xform == "tolower") {
     ret["env"] = bindrcpp::create_env_string(
-      names, &CallbackTester::tolower_static, PAYLOAD(pc), parent);
+      names, List::create(&CallbackTester::tolower_static, PAYLOAD(pc)), parent);
   }
   else if (xform == "toupper") {
     ret["env"] = bindrcpp::create_env_string(
-      names, &CallbackTester::toupper_static, PAYLOAD(pc), parent);
+      names, List::create(&CallbackTester::toupper_static, PAYLOAD(pc)), parent);
   }
   else
     stop("unknown xform");

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -84,11 +84,11 @@ List do_test_create_environment(CharacterVector names, String xform, Environment
 
   if (xform == "tolower") {
     ret["env"] = bindrcpp::create_env_string(
-      names, List::create(&CallbackTester::tolower_static, PAYLOAD(pc)), parent);
+      names, &CallbackTester::tolower_static, PAYLOAD(pc), parent);
   }
   else if (xform == "toupper") {
     ret["env"] = bindrcpp::create_env_string(
-      names, List::create(&CallbackTester::toupper_static, PAYLOAD(pc)), parent);
+      names, &CallbackTester::toupper_static, PAYLOAD(pc), parent);
   }
   else
     stop("unknown xform");

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -1,14 +1,20 @@
 context("create")
 
-test_that("cpp_create_environment()", {
-  env_cb <- cpp_create_environment(letters, "toupper")
-  env <- env_cb$env
-  expect_equal(env$a, "A")
-  expect_equal(env$x, "X")
-  expect_null(env$X)
-  expect_equal(length(ls(env)), length(letters))
-  expect_error(env$a <- "a", "read-only")
-})
+gctorture2(29)
+
+for (i in 1:100) {
+
+print(i)
+
+# test_that("cpp_create_environment()", {
+#   env_cb <- cpp_create_environment(letters, "toupper")
+#   env <- env_cb$env
+#   expect_equal(env$a, "A")
+#   expect_equal(env$x, "X")
+#   expect_null(env$X)
+#   expect_equal(length(ls(env)), length(letters))
+#   expect_error(env$a <- "a", "read-only")
+# })
 
 test_that("cpp_create_environment() with inheritance", {
   env_cb <- cpp_create_environment(letters, "toupper")
@@ -26,3 +32,5 @@ test_that("cpp_create_environment() with inheritance", {
   expect_error(env2$a <- "a", NA)
   expect_equal(get("a", env2), "a")
 })
+
+}


### PR DESCRIPTION
related to tidyverse/dplyr#2811.

- Wrapping function pointers is not portable, using a wrapper struct now.